### PR TITLE
Refactor to use partially applied functions for dependency injection …

### DIFF
--- a/SeatsSuggestions/SeatsSuggestions.Api/Controllers/SeatsSuggestionsController.cs
+++ b/SeatsSuggestions/SeatsSuggestions.Api/Controllers/SeatsSuggestionsController.cs
@@ -17,9 +17,9 @@ namespace SeatsSuggestions.Api.Controllers
     [Route("api/v{version:apiVersion}/[controller]")]
     public class SeatsSuggestionsController : ControllerBase
     {
-        private readonly Func<ShowId, PartyRequested, Task<SuggestionsMade>> _suggestionsDelegate;
+        private readonly SeatAllocator.SuggestionsDelegate _suggestionsDelegate;
 
-        public SeatsSuggestionsController(Func<ShowId, PartyRequested, Task<SuggestionsMade>> suggestionDelegate)
+        public SeatsSuggestionsController(SeatAllocator.SuggestionsDelegate suggestionDelegate)
         {
             _suggestionsDelegate = suggestionDelegate;
         }

--- a/SeatsSuggestions/SeatsSuggestions.Api/SeatsSuggestions.Api.xml
+++ b/SeatsSuggestions/SeatsSuggestions.Api/SeatsSuggestions.Api.xml
@@ -6,7 +6,7 @@
     <members>
         <member name="T:SeatsSuggestions.Api.Controllers.SeatsSuggestionsController">
             <summary>
-                Web controller acting as a left-side Adapter of a Hexagonal Architecture.
+                Web controller acting as the Imperative Shell for our Suggestions use case.
             </summary>
         </member>
         <member name="T:SeatsSuggestions.Api.ServiceCollectionExtension">

--- a/SeatsSuggestions/SeatsSuggestions.Domain/SeatAllocator.cs
+++ b/SeatsSuggestions/SeatsSuggestions.Domain/SeatAllocator.cs
@@ -11,6 +11,8 @@ namespace SeatsSuggestions.Domain
     {
         private const int NumberOfSuggestionsPerPricingCategory = 3;
 
+        public delegate Task<SuggestionsMade> SuggestionsDelegate(ShowId id, PartyRequested party);
+
         public async static Task<SuggestionsMade> MakeSuggestionsImperativeShell(Ports.IProvideUpToDateAuditoriumSeating auditoriumSeatingProvider, ShowId id, PartyRequested partyRequested)
         {
             // non-pure function

--- a/SeatsSuggestions/SeatsSuggestions.Domain/SeatAllocator.cs
+++ b/SeatsSuggestions/SeatsSuggestions.Domain/SeatAllocator.cs
@@ -1,14 +1,33 @@
 ﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using SeatsSuggestions.Domain.Helper;
 
 namespace SeatsSuggestions.Domain
 {
     /// <summary>
-    ///     The functional core.
+    ///     The functional and imperative shell/orchestration core.
     /// </summary>
     public static class SeatAllocator
     {
         private const int NumberOfSuggestionsPerPricingCategory = 3;
+
+        public async static Task<SuggestionsMade> MakeSuggestionsImperativeShell(Ports.IProvideUpToDateAuditoriumSeating auditoriumSeatingProvider, ShowId id, PartyRequested partyRequested)
+        {
+            // non-pure function
+            var auditoriumSeating = await auditoriumSeatingProvider.GetAuditoriumSeating(id);
+
+            // call pure function
+            return SeatAllocator
+                .TryMakeSuggestions(id, partyRequested, auditoriumSeating)
+                    .GetValueOrFallback(new SuggestionNotAvailable(id, partyRequested));
+
+            // Balance restored:
+            // - inner hexagon knows about adapter capabilities but not implementation
+            // - orchestration is back in the 'core' where we can locally reason about it
+            
+            // Notes: 
+            // in this case the imperative shells can be easily distinguished by the 'async' keyword which kind of plays the role of the IO<> marker type. 
+        }
 
         public static Maybe<SuggestionsMade> TryMakeSuggestions(ShowId showId, PartyRequested partyRequested, AuditoriumSeating auditoriumSeating)
         {

--- a/SeatsSuggestions/TheaterSuggestions.Tests/Tools/ImperativeShellBuilder.cs
+++ b/SeatsSuggestions/TheaterSuggestions.Tests/Tools/ImperativeShellBuilder.cs
@@ -1,7 +1,10 @@
 ﻿using ExternalDependencies;
 using SeatsSuggestions.Api.Controllers;
+using SeatsSuggestions.Domain;
 using SeatsSuggestions.Infra;
 using SeatsSuggestions.Infra.Adapter;
+using System;
+using System.Threading.Tasks;
 
 namespace SeatsSuggestions.Tests.Tools
 {
@@ -32,8 +35,16 @@ namespace SeatsSuggestions.Tests.Tools
             // Instantiate the Right-side adapter
             var rightSideAdapter = InstantiateRightSideAdapter(_showId, _theaterJson, _theaterBookedSeatsJson);
 
+            // create impure imperative shell by partially applying the provide function in the core.
+            Func<ShowId, PartyRequested, Task<SuggestionsMade>> suggestionsDelegate = (id, party) => SeatAllocator.MakeSuggestionsImperativeShell(rightSideAdapter, id, party);
+
             // Instantiate the Left-side adapter
-            var leftSideAdapter = new SeatsSuggestionsController(rightSideAdapter);
+            var leftSideAdapter = new SeatsSuggestionsController(suggestionsDelegate);
+
+            // Balance restored : Underlying hexagon (essentially the 'main' module) knows how to assemble adapters to core but nothing else
+            
+            // Note: 
+            // - iso injecting the functions into the controller and rightside adapters, these could also be injected by creting more partially applied functions YMMV
 
             return leftSideAdapter;
         }

--- a/SeatsSuggestions/TheaterSuggestions.Tests/Tools/ImperativeShellBuilder.cs
+++ b/SeatsSuggestions/TheaterSuggestions.Tests/Tools/ImperativeShellBuilder.cs
@@ -36,7 +36,7 @@ namespace SeatsSuggestions.Tests.Tools
             var rightSideAdapter = InstantiateRightSideAdapter(_showId, _theaterJson, _theaterBookedSeatsJson);
 
             // create impure imperative shell by partially applying the provide function in the core.
-            Func<ShowId, PartyRequested, Task<SuggestionsMade>> suggestionsDelegate = (id, party) => SeatAllocator.MakeSuggestionsImperativeShell(rightSideAdapter, id, party);
+            SeatAllocator.SuggestionsDelegate suggestionsDelegate = (id, party) => SeatAllocator.MakeSuggestionsImperativeShell(rightSideAdapter, id, party);
 
             // Instantiate the Left-side adapter
             var leftSideAdapter = new SeatsSuggestionsController(suggestionsDelegate);


### PR DESCRIPTION
…and to restore the balance about modules knowledge of the world.

I was very interested in the functional core meetup and I was the one asking the question about passing functions around to keep the module knowledge assumptions in balance compared to the spirit of the hexagon.

I am not a C# programmer (this is probably my first attempt) so please try to look through my pitiful attempts to see how the ideas of dependency injection/hexagon/imperative shell/functional core can be done according to me.